### PR TITLE
Updates to INSTALL.rst documentation - no code changes

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,6 +4,8 @@ SYSFS{idVendor}=="0694", SYSFS{idProduct}=="0003", MODE="0666"
 
 For Ubuntu Linux 14.04 and newer, the udev syntax has changed.
 
-SUBSYSTEM=="usb", ATTR{idVendor}=="0694", ATTR{idProduct}=="0003", MODE:="0666"
+In a file called /etc/udev/rules.d/lego-wedo.rules: Add the following line:
 
-Note the colon on the MODE assignment. 
+    SUBSYSTEM=="usb", ATTR{idVendor}=="0694", ATTR{idProduct}=="0003", MODE:="0666"
+
+Note the colon on the MODE assignment and the use of ATTR.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,3 +1,9 @@
 Add your user on in the usb group or add this file to this rule to udev.d :
 
 SYSFS{idVendor}=="0694", SYSFS{idProduct}=="0003", MODE="0666"
+
+For Ubuntu Linux 14.04 and newer, the udev syntax has changed.
+
+SUBSYSTEM=="usb", ATTR{idVendor}=="0694", ATTR{idProduct}=="0003", MODE:="0666"
+
+Note the colon on the MODE assignment. 


### PR DESCRIPTION
The udev information in the `INSTALL.rst` is out of date and does not work with newer versions of Ubuntu. This pull request updates the information in that file to include a working example of a udev rule